### PR TITLE
Fix typo in uploader.ts

### DIFF
--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -14,7 +14,7 @@ function uploadFile(entry: readdirp.EntryInfo, storageName: string, accessKey: s
     body: readStream
   }).then(response => {
     if (response.status === 201) {
-      info(`Successfull deployment of ${entry.path}`);
+      info(`Successfully deployed ${entry.path}`);
     } else {
       throw new Error(`Uploading ${entry.path} has failed width status code ${response.status}.`);
     }


### PR DESCRIPTION
Hello Snider, thanks a lot for providing this repo. 

I've seen a small typo in `src/uploader.ts`, where the word `successfull` is mispelled `successful`. This PR fixes this. 